### PR TITLE
Remove AppAttest from UI and stub image generation

### DIFF
--- a/EchoEdit/StoreKitService.swift
+++ b/EchoEdit/StoreKitService.swift
@@ -12,7 +12,7 @@ class StoreKitService: ObservableObject {
     private var subscriptionProduct: Product?
     private var creditsProduct: Product?
     private var updateListenerTask: Task<Void, Error>?
-    private let appAttestService: AppAttestService
+    private let appAttestService = AppAttestService()
     
     enum SubscriptionStatus {
         case unknown
@@ -24,8 +24,7 @@ class StoreKitService: ObservableObject {
     let subscriptionProductID = "echoedit.monthly.subscription"
     let creditsProductID = "echoedit.credits.25pack"
     
-    init(appAttestService: AppAttestService) {
-        self.appAttestService = appAttestService
+    init() {
         updateListenerTask = listenForTransactions()
         Task {
             await requestProducts()


### PR DESCRIPTION
## Summary
- eliminate `AppAttestService` references from `ContentView`
- instantiate `StoreKitService` without passing attestation
- drop secure service helpers and attestation task
- stub out `generateImage()` with a minimal placeholder

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68802542607c8331a392e5f6c08759fd